### PR TITLE
Potential fix for code scanning alert no. 2: Use of externally-controlled format string

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -20,7 +20,8 @@ if (!process.env.OPENFORT_SECRET_KEY) {
 const openfort = new Openfort(process.env.OPENFORT_SECRET_KEY);
 
 async function createEncryptionSession(req: Request, res: Response) {
-  console.log(`[${req.headers['user-agent']?.split(' ')[0]}]`, 'Creating encryption session...');
+  const uaHead = String(req.headers['user-agent']?.split(' ')[0] || 'unknown').replace(/[\[\]]/g, ''); // Remove brackets to prevent log injection
+  console.log('[%s] Creating encryption session...', uaHead);
 
   try {
     const shieldApiKey = process.env.SHIELD_API_KEY;


### PR DESCRIPTION
Potential fix for [https://github.com/openfort-xyz/openfort-backend-quickstart/security/code-scanning/2](https://github.com/openfort-xyz/openfort-backend-quickstart/security/code-scanning/2)

To fix the problem, we should sanitize the user input from `req.headers['user-agent']` before including it in log statements. Instead of directly interpolating the first word of the `User-Agent` header in the log output, we can pass it as a separate argument, using a `%s` specifier as recommended, so that any formatting characters in the input are treated as data. Also, it's best to explicitly convert the value to a string and escape square brackets to prevent log injection attacks. For the code in `src/app.ts`, change line 23 to use `console.log('%s Creating encryption session...', `[${String(req.headers['user-agent']?.split(' ')[0] || 'unknown')}]`)`, or similar, avoiding interpolation. Ensure no other functionality is changed. No additional imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
